### PR TITLE
Enable Compiler tests on Windows

### DIFF
--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -267,7 +267,8 @@ jobs:
           cd julia-*/
 
           bin/julia.exe -e 'using InteractiveUtils; InteractiveUtils.versioninfo()'
-          bin/julia.exe -e "Base.runtests(\"all --ci --skip Pkg Sockets cmdlineargs\"; ncores=4)"
+          bin/julia.exe -e "Base.runtests(\"all --ci --skip Pkg Sockets cmdlineargs compiler\"; ncores=4)"
+          bin/julia.exe -e "Base.runtests(\"compiler\"; ncores=1)"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/build-and-test-template.yml
+++ b/.github/workflows/build-and-test-template.yml
@@ -267,7 +267,7 @@ jobs:
           cd julia-*/
 
           bin/julia.exe -e 'using InteractiveUtils; InteractiveUtils.versioninfo()'
-          bin/julia.exe -e "Base.runtests(\"all --ci --skip Pkg Sockets cmdlineargs compiler\"; ncores=4)"
+          bin/julia.exe -e "Base.runtests(\"all --ci --skip Pkg Sockets cmdlineargs\"; ncores=4)"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
These used to prevent the tests from finishing, they seemed to just hang at the end.